### PR TITLE
BugFix: When JavaScript calls a registered Android method with JSON Obje...

### DIFF
--- a/Android/WebViewJavascriptBridge/res/raw/webviewjavascriptbridge.js
+++ b/Android/WebViewJavascriptBridge/res/raw/webviewjavascriptbridge.js
@@ -30,7 +30,7 @@
 			message['callbackId'] = callbackId
 			}
 				console.log("sending:"+JSON.stringify(message));
-		_WebViewJavascriptBridge._handleMessageFromJs(message.data||null,message.responseId||null,
+		_WebViewJavascriptBridge._handleMessageFromJs(JSON.stringify(message.data)||null,message.responseId||null,
 		    message.responseData||null,message.callbackId||null,message.handlerName||null);
 
 	}

--- a/Android/WebViewJavascriptBridge/res/raw/webviewjavascriptbridge.js
+++ b/Android/WebViewJavascriptBridge/res/raw/webviewjavascriptbridge.js
@@ -30,7 +30,7 @@
 			message['callbackId'] = callbackId
 			}
 				console.log("sending:"+JSON.stringify(message));
-		_WebViewJavascriptBridge._handleMessageFromJs(JSON.stringify(message.data)||null,message.responseId||null,
+		_WebViewJavascriptBridge._handleMessageFromJs((typeof message.data == 'string') && message.data.constructor==String ? message.data : JSON.stringify(message.data)||null,message.responseId||null,
 		    message.responseData||null,message.callbackId||null,message.handlerName||null);
 
 	}
@@ -42,7 +42,7 @@
 			if (message.responseId) {
 				var responseCallback = responseCallbacks[message.responseId]
 				if (!responseCallback) { return; }
-				responseCallback(message.responseData)
+				responseCallback((typeof message.responseData == 'string') && message.responseData.constructor==String ? message.responseData : JSON.parse(message.responseData))
 				delete responseCallbacks[message.responseId]
 			} else {
 				var responseCallback


### PR DESCRIPTION
The Android "handle" method will get an "undefined" String when JavaScript calls a registered Android method with JSON Object.
This fix simply passes JSON.stringify(message.data) to the Android world instead of passing message.data directly.
